### PR TITLE
Include correct macro to check for files

### DIFF
--- a/source/compiler/CMakeLists.txt
+++ b/source/compiler/CMakeLists.txt
@@ -18,7 +18,7 @@ project(pawnc
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../../cmake)
 #==============================================================================#
-include(CheckIncludeFile)
+include(CheckIncludeFiles)
 include(CheckFunctionExists)
 
 # check for optional include files


### PR DESCRIPTION
Looks like you replaced macro `check_include_file` with `check_include_files` but you forgot to actually include it, resulting in an error.
